### PR TITLE
ci(eslint): fix plugins and configure linting rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,8 +2,15 @@
 const eslint = require('@eslint/js');
 const tseslint = require('typescript-eslint');
 const angular = require('angular-eslint');
+const prettierRecommended = require('eslint-plugin-prettier/recommended');
+const eslintPluginImport = require('eslint-plugin-import');
+const simpleImportSort = require('eslint-plugin-simple-import-sort');
+const unicorn = require('eslint-plugin-unicorn');
+const unusedImports = require('eslint-plugin-unused-imports');
+const storybook = require('eslint-plugin-storybook');
 
 module.exports = tseslint.config(
+  ...storybook.configs['flat/recommended'],
   {
     files: ['**/*.ts'],
     extends: [
@@ -13,6 +20,12 @@ module.exports = tseslint.config(
       ...angular.configs.tsRecommended,
     ],
     processor: angular.processInlineTemplates,
+    plugins: {
+      'simple-import-sort': simpleImportSort,
+      'import/recommended': eslintPluginImport.flatConfigs,
+      unicorn: unicorn,
+      'unused-imports': unusedImports,
+    },
     rules: {
       '@angular-eslint/directive-selector': [
         'error',
@@ -30,11 +43,31 @@ module.exports = tseslint.config(
           style: 'kebab-case',
         },
       ],
+      'simple-import-sort/imports': 'warn',
+      'simple-import-sort/exports': 'warn',
+      'unused-imports/no-unused-imports': 'warn',
     },
   },
   {
     files: ['**/*.html'],
     extends: [...angular.configs.templateRecommended, ...angular.configs.templateAccessibility],
-    rules: {},
+    rules: {
+      '@angular-eslint/template/prefer-self-closing-tags': ['error'],
+    },
+  },
+  {
+    files: ['**/*.html', '**/*.ts'],
+    extends: [prettierRecommended],
+    rules: {
+      'prettier/prettier': [
+        'warn',
+        {
+          endOfLine: 'auto',
+        },
+      ],
+    },
+  },
+  {
+    ignores: ['!.storybook'],
   }
 );

--- a/package.json
+++ b/package.json
@@ -123,10 +123,5 @@
     "stylelint-config-standard-scss": "^14.0.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "8.29.1"
-  },
-  "eslintConfig": {
-    "extends": [
-      "plugin:storybook/recommended"
-    ]
   }
 }

--- a/src/schematics/components/files/button/button.stories.ts
+++ b/src/schematics/components/files/button/button.stories.ts
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/angular';
+
 import { ZenButtonComponent } from './button.component';
 
 export default {

--- a/src/schematics/components/files/checkbox/checkbox.component.ts
+++ b/src/schematics/components/files/checkbox/checkbox.component.ts
@@ -1,5 +1,5 @@
-import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { booleanAttribute, ChangeDetectionStrategy, Component, forwardRef, input, model } from '@angular/core';
+import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 /**
  * ZenCheckboxComponent is a reusable checkbox component designed to provide

--- a/src/schematics/components/files/checkbox/checkbox.stories.ts
+++ b/src/schematics/components/files/checkbox/checkbox.stories.ts
@@ -1,4 +1,5 @@
 import { Meta, StoryObj } from '@storybook/angular';
+
 import { ZenCheckboxComponent } from './checkbox.component';
 
 export default {

--- a/src/schematics/components/files/input/input.stories.ts
+++ b/src/schematics/components/files/input/input.stories.ts
@@ -1,4 +1,5 @@
 import { Meta, StoryObj } from '@storybook/angular';
+
 import { ZenInputComponent } from './input.component';
 
 export default {

--- a/src/schematics/components/files/switch/switch.stories.ts
+++ b/src/schematics/components/files/switch/switch.stories.ts
@@ -1,4 +1,5 @@
 import { Meta, StoryObj } from '@storybook/angular';
+
 import { ZenSwitchComponent } from './switch.component';
 
 export default {

--- a/src/schematics/components/files/textarea/textarea.stories.ts
+++ b/src/schematics/components/files/textarea/textarea.stories.ts
@@ -1,4 +1,5 @@
 import { Meta, StoryObj } from '@storybook/angular';
+
 import { ZenTextareaComponent } from './textarea.component';
 
 interface StoryParams {

--- a/src/utils/apply-file-template.util.ts
+++ b/src/utils/apply-file-template.util.ts
@@ -1,5 +1,6 @@
 import { normalize, strings } from '@angular-devkit/core';
 import { apply, applyTemplates, chain, filter, mergeWith, move, Rule, url } from '@angular-devkit/schematics';
+
 import { GeneratorSchemaBase } from '../types';
 import { SchematicsFolder } from '../types/schematics-folder.type';
 


### PR DESCRIPTION
- integrate eslint plugins: prettier, import, unicorn, storybook, and unused-imports
- configure simple-import-sort and unused-imports rules
- enhance template linting with self-closing tags enforcement
- apply prettier recommendations for consistent formatting