### PR TITLE
feat(icon): remove @hugeicons/angular package & improvements

### DIFF
--- a/src/schematics/components/files/icon/icon.stories.ts
+++ b/src/schematics/components/files/icon/icon.stories.ts
@@ -8,14 +8,24 @@ export default {
   title: 'Components/Icon',
   component: ZenIcon,
   tags: ['autodocs'],
+  argTypes: {
+    size: { control: { type: 'range', min: 12, max: 100, step: 1 }, description: 'Size' },
+    strokeWidth: { control: { type: 'range', min: 1, max: 5, step: 0.25 }, description: 'strokeWidth' },
+    absoluteStrokeWidth: { control: 'boolean' },
+  },
+  args: {
+    size: 64,
+    strokeWidth: 1.5,
+    absoluteStrokeWidth: false,
+  },
 } satisfies Meta<Options>;
 
 type Story = StoryObj<Options>;
 
 export const Default: Story = {
-  render: () => ({
+  render: args => ({
     template: `
-        <zen-icon icon="Tree02Icon" [size]="64"/>
+        <zen-icon icon="Tree02Icon" [size]="${args.size}" [strokeWidth]="${args.strokeWidth}" ${args.absoluteStrokeWidth ? 'absoluteStrokeWidth' : ''}>
     `,
   }),
 };

--- a/src/schematics/components/files/icon/icon.ts
+++ b/src/schematics/components/files/icon/icon.ts
@@ -1,35 +1,79 @@
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
-import { HugeiconsIconComponent } from '@hugeicons/angular';
+import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 import * as icons from '@hugeicons/core-free-icons';
 
 type Icon = keyof typeof icons;
+interface Path {
+  d: string | number;
+  fill: string | number;
+  opacity: string | number;
+  fillRule: string | number;
+  strokeWidth?: number;
+}
 
 /**
  * A reusable Angular component for rendering icons from the Hugeicons library.
  *
- * This component acts as a wrapper around the `<hugeicons-icon>` component, allowing you to display any icon from the
- * `@hugeicons/core-free-icons` collection by specifying its name. The icon, size, and stroke width are fully configurable
- * via inputs.
+ * This component renders an SVG icon from the `@hugeicons/core-free-icons` collection by name.
+ * The size, stroke width, and color are configurable through inputs. It dynamically generates the SVG
+ * and its paths, providing a flexible and efficient way to use Hugeicons in an Angular application.
  *
  * @example
  * <zen-icon icon="Tree02Icon" />
  *
- * @author Konrad Stępień
- * @license {@link https://github.com/kstepien3/ng-zen/blob/master/LICENSE|BSD-2-Clause}
- * @see [GitHub](https://github.com/kstepien3/ng-zen)
+ * @license {@link https://github.com/hugeicons/angular/blob/main/README.md#license|MIT}
  * @see [Hugeicons](https://hugeicons.com)
  */
 @Component({
   selector: 'zen-icon',
   template: `
-    <hugeicons-icon [icon]="icon()" [size]="size()" [strokeWidth]="strokeWidth()" color="currentColor" />
+    <svg
+      [attr.color]="color()"
+      [attr.height]="size()"
+      [attr.width]="size()"
+      fill="none"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      @for (path of paths(); track path) {
+        <path
+          [attr.d]="path.d"
+          [attr.fill-rule]="path.fillRule"
+          [attr.fill]="path.fill"
+          [attr.opacity]="path.opacity"
+          [attr.stroke-width]="path.strokeWidth"
+          [attr.stroke]="'currentColor'"
+        />
+      }
+    </svg>
   `,
-  imports: [HugeiconsIconComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ZenIcon {
   /** Icon file names from HugeIcons */
   readonly icon = input.required({ transform: (icon: Icon) => icons[icon] });
   readonly size = input<number>(24);
+  readonly absoluteStrokeWidth = input<boolean, unknown>(false, { transform: booleanAttribute });
   readonly strokeWidth = input<number>(1.5);
+  readonly color = input<string>('currentColor');
+
+  readonly paths = computed<Path[]>(() => this.updatePaths());
+
+  private readonly calculatedStrokeWidth = computed(() => this.calculateStrokeWidth());
+
+  private calculateStrokeWidth(): number {
+    if (!this.absoluteStrokeWidth()) return this.strokeWidth();
+
+    const BASE_SIZE = 24;
+    return (this.strokeWidth() * BASE_SIZE) / this.size();
+  }
+
+  private updatePaths(): Path[] {
+    return this.icon().map(([, attrs]) => ({
+      d: attrs['d'],
+      fill: attrs['fill'] ?? 'none',
+      opacity: attrs['opacity'],
+      fillRule: attrs['fillRule'],
+      strokeWidth: this.calculatedStrokeWidth(),
+    }));
+  }
 }

--- a/src/schematics/dependency-manager/dependencies.constant.ts
+++ b/src/schematics/dependency-manager/dependencies.constant.ts
@@ -3,7 +3,6 @@ import { FilesConfig } from '../../types';
 export const DEPENDENCIES_CONFIG: Partial<FilesConfig> = {
   icon: {
     dependencies: {
-      '@hugeicons/angular': 'latest',
       '@hugeicons/core-free-icons': 'latest',
     },
   },


### PR DESCRIPTION
Refactored code works better than the original.
The benefit of this is also, the `@hugeicons/angular` is no longer necessary.