### PR TITLE
fix(form-control): move placeholder into the input component

### DIFF
--- a/src/schematics/components/files/form-control/form-control.stories.ts
+++ b/src/schematics/components/files/form-control/form-control.stories.ts
@@ -17,7 +17,6 @@ export default {
   },
   argTypes: {
     value: { control: false },
-    placeholder: { control: false },
     disabled: { control: 'boolean' },
     required: { control: 'boolean' },
   },

--- a/src/schematics/components/files/form-control/form-control.ts
+++ b/src/schematics/components/files/form-control/form-control.ts
@@ -41,9 +41,6 @@ export abstract class ZenFormControl<Value> implements ControlValueAccessor {
    */
   abstract readonly value: ModelSignal<Value>;
 
-  /** The placeholder text for the form control. */
-  readonly placeholder = input<string>();
-
   /**
    * Whether the form control is disabled.
    */

--- a/src/schematics/components/files/input/input.ts
+++ b/src/schematics/components/files/input/input.ts
@@ -1,7 +1,7 @@
-import { ChangeDetectionStrategy, Component, model } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, model } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
-import { ZenFormControl, ZenFormControlProvider } from '../form-control/form-control';
+import { ZenFormControl, ZenFormControlProvider } from '../form-control';
 
 /**
  * ZenInput is a reusable text input component designed to provide
@@ -51,4 +51,7 @@ import { ZenFormControl, ZenFormControlProvider } from '../form-control/form-con
 })
 export class ZenInput extends ZenFormControl<string> {
   readonly value = model('');
+
+  /** The placeholder text for the form control. */
+  readonly placeholder = input<string>();
 }


### PR DESCRIPTION
Only the `input` uses the `placeholder` prop, it shouldn't be available in other components