### PR TITLE
refactor(divider): improve css variables

### DIFF
--- a/src/schematics/components/files/divider/divider.scss
+++ b/src/schematics/components/files/divider/divider.scss
@@ -1,15 +1,18 @@
-$appearance: var(--zen-divider-appearance, hsl(0deg 0% 60%));
-$type: var(--zen-divider-type, solid);
-$align-offset: var(--zen-divider-align-offset, 25%);
-$gap: var(--zen-divider-gap, 0.25rem);
-$thickness: var(--zen-divider-thickness, 1px);
-
 :host {
+  --zen-divider-appearance: hsl(0deg 0% 60%);
+  --zen-divider-type: solid;
+  --zen-divider-align-offset: 25%;
+  --zen-divider-gap: 0.25rem;
+  --zen-divider-thickness: 1px;
+}
+
+/* stylelint-disable-next-line no-duplicate-selectors -- separate variables and styles */
+:host {
+  color: var(--zen-divider-appearance);
+  gap: var(--zen-divider-gap);
   width: 100%;
   display: flex;
   align-items: center;
-  gap: $gap;
-  color: $appearance;
 
   &::before,
   &::after {
@@ -17,12 +20,12 @@ $thickness: var(--zen-divider-thickness, 1px);
     display: block;
     width: 100%;
     height: 0;
-    border-color: $appearance;
-    border-style: $type;
-    border-width: #{$thickness} 0 0;
+    border-color: var(--zen-divider-appearance);
+    border-style: var(--zen-divider-type);
+    border-width: var(--zen-divider-thickness) 0 0;
   }
 
-  &:not(.has-content) {
+  &:empty {
     gap: 0;
 
     &::after {
@@ -32,7 +35,7 @@ $thickness: var(--zen-divider-thickness, 1px);
 
   &.zen-align-start::before,
   &.zen-align-end::after {
-    width: $align-offset;
+    width: var(--zen-divider-align-offset);
   }
 }
 
@@ -47,11 +50,11 @@ $thickness: var(--zen-divider-thickness, 1px);
     display: block;
     width: unset;
     height: 100%;
-    border-width: 0 #{$thickness} 0 0;
+    border-width: 0 var(--zen-divider-thickness) 0 0;
   }
 
   &.zen-align-start::before,
   &.zen-align-end::after {
-    height: $align-offset;
+    height: var(--zen-divider-align-offset);
   }
 }

--- a/src/schematics/components/files/divider/divider.ts
+++ b/src/schematics/components/files/divider/divider.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, ElementRef, inject, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 
 /**
  * ZenDivider is a reusable divider component that provides a simple way to
@@ -38,21 +38,10 @@ import { ChangeDetectionStrategy, Component, computed, ElementRef, inject, input
   styleUrl: './divider.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
-    '[class.has-content]': 'hasContent()',
     '[class]': '"zen-align-"+align()',
   },
 })
 export class ZenDivider {
   /** Controls the alignment of content within the divider. */
   readonly align = input<'start' | 'end' | 'center'>('center');
-
-  /**
-   * Computed property that determines if the divider contains any content.
-   * Used to apply appropriate styling when content is present.
-   */
-  protected readonly hasContent = computed(() => {
-    return this.elementRef.nativeElement.childNodes.length > 0;
-  });
-
-  private readonly elementRef = inject(ElementRef);
 }


### PR DESCRIPTION
move CSS variables into separated host block for better development debugging in browsers

use `:empty` instead of ts logic