### PR TITLE
refactor(checkbox): improve css variables

### DIFF
--- a/src/schematics/components/files/checkbox/checkbox.scss
+++ b/src/schematics/components/files/checkbox/checkbox.scss
@@ -1,17 +1,16 @@
-// Component Variables
-$size: var(--zen-checkbox-size, 16px);
-$border-radius: var(--zen-checkbox-border-radius, 6px);
-$focus-shadow: var(--zen-checkbox-focus-shadow, 0 1px 4px hsl(0deg 0% 60% / 20%) inset);
-
-// Color Palette
-$appearance: var(--zen-checkbox-appearance, hsl(0deg 0% 10%));
-$disabled-opacity: var(--zen-checkbox-disabled-opacity, 0.6);
-$border: var(--zen-checkbox-border, 1px solid hsl(0deg 0% 80%));
+// Globals
 $error: var(--zen-error, hsl(0deg 70% 50%));
+$focus-shadow: var(--zen-focus-shadow, 0 1px 4px hsl(0deg 0% 60% / 20%) inset);
 $outline: var(--zen-outline, 2px solid hsl(200deg 100% 50% / 50%));
-
-// Animations
 $transition-duration: var(--zen-transition-duration, 0.2s);
+
+:host {
+  --zen-checkbox-size: 1rem;
+  --zen-checkbox-border-radius: 0.375rem; // 6px
+  --zen-checkbox-appearance: hsl(0deg 0% 10%);
+  --zen-checkbox-disabled-opacity: 0.6;
+  --zen-checkbox-border: 1px solid hsl(0deg 0% 80%);
+}
 
 input {
   position: absolute;
@@ -25,13 +24,14 @@ input {
   left: 0;
 }
 
+/* stylelint-disable-next-line no-duplicate-selectors -- separate variables and styles */
 :host {
+  border: var(--zen-checkbox-border);
+  border-radius: var(--zen-checkbox-border-radius);
+  height: var(--zen-checkbox-size);
+  width: var(--zen-checkbox-size);
   background-color: white;
   cursor: pointer;
-  border: $border;
-  border-radius: $border-radius;
-  height: $size;
-  width: $size;
   position: relative;
   transition:
     background-color ease,
@@ -42,28 +42,28 @@ input {
   display: grid;
   place-items: center;
   font-size: small;
-}
 
-:host:has(input:checked) {
-  color: white;
-  background-color: $appearance;
-  border-color: $appearance;
-}
-
-:host:has(input[type='checkbox']:disabled) {
-  opacity: $disabled-opacity;
-
-  &,
-  input {
-    cursor: not-allowed;
+  &:has(input:checked) {
+    color: white;
+    background-color: var(--zen-checkbox-appearance);
+    border-color: var(--zen-checkbox-appearance);
   }
-}
 
-:host:has(input:focus-visible) {
-  outline: $outline;
-  box-shadow: $focus-shadow;
-}
+  &:has(input[type='checkbox']:disabled) {
+    opacity: var(--zen-checkbox-disabled-opacity);
 
-:host:has(input:user-invalid) {
-  border-color: $error;
+    &,
+    input {
+      cursor: not-allowed;
+    }
+  }
+
+  &:has(input:focus-visible) {
+    outline: $outline;
+    box-shadow: $focus-shadow;
+  }
+
+  &:has(input:user-invalid) {
+    border-color: $error;
+  }
 }

--- a/src/schematics/components/files/checkbox/checkbox.ts
+++ b/src/schematics/components/files/checkbox/checkbox.ts
@@ -20,9 +20,8 @@ import { ZenFormControl, ZenFormControlProvider } from '../form-control';
  *
  * ```css
  * :root {
- *  --zen-checkbox-size: 16px;
- *  --zen-checkbox-border-radius: 6px;
- *  --zen-checkbox-focus-shadow: 0 1px 4px hsl(0deg 0% 60% / 20%) inset;
+ *  --zen-checkbox-size: 1rem;
+ *  --zen-checkbox-border-radius: 0.375rem;
  *  --zen-checkbox-appearance: hsl(0deg 0% 10%);
  *  --zen-checkbox-disabled-opacity: 0.6;
  *  --zen-checkbox-border: 1px solid hsl(0deg 0% 80%);


### PR DESCRIPTION
move CSS variables into separated host block for better development debugging in browsers

use rem instead of px